### PR TITLE
Removed scope bug for location NPID for reconcilation

### DIFF
--- a/app/jobs/location_npid_job.rb
+++ b/app/jobs/location_npid_job.rb
@@ -3,8 +3,8 @@ class LocationNpidJob < ApplicationJob
 
   def perform(*args)
     # Do something later
-    location_npid_balance = LocationNpid.all.group(:assigned).count
-    dashboard_stat = DashboardStat.find_or_create_by(name: "location_npid_balance", value: {}) do |stat|
+    location_npid_balance = LocationNpid.unscoped.group(:assigned).count
+    dashboard_stat = DashboardStat.find_or_create_by(name: 'location_npid_balance', value: {}) do |stat|
       stat.value = {}
     end
     dashboard_stat.update(value: location_npid_balance)


### PR DESCRIPTION
Due to adding of allocated column to the Location Npids table and default scope of assigned: false and allocated: false the method for counting the allocated Location NPIDs was not working because of the default scope. 

Solution: Unscoped the counting of the assigned Location NPIDs