### PR TITLE
Handle invalid/empty token file in SyncJob#authorize

### DIFF
--- a/app/jobs/sync_job.rb
+++ b/app/jobs/sync_job.rb
@@ -82,16 +82,21 @@ class SyncJob < ApplicationJob
 
   def authorize
     if File.exist?("#{Rails.root}/tmp/token.json")
-      @token = JSON.parse(File.read("#{Rails.root}/tmp/token.json")).symbolize_keys[:token]
-      return @token if token_valid(@token)
+      content = File.read("#{Rails.root}/tmp/token.json").strip
+      @token = content.present? ? JSON.parse(content).symbolize_keys[:token] : nil
+      return @token if @token.present? && token_valid(@token)
 
       @token = authenticate
       File.write("#{Rails.root}/tmp/token.json", { token: @token }.to_json)
-
     else
       @token = authenticate
       File.write("#{Rails.root}/tmp/token.json", { token: @token }.to_json)
     end
+  rescue JSON::ParserError, NoMethodError, TypeError => e
+    Rails.logger.warn "SyncJob#authorize: Invalid token file (#{e.class}: #{e.message}). Re-authenticating..."
+    log_error("SyncJob#authorize: Invalid token file (#{e.class}: #{e.message}). Re-authenticating...")
+    @token = authenticate
+    File.write("#{Rails.root}/tmp/token.json", { token: @token }.to_json)
   end
 
   def authenticate

--- a/bin/dde4_update_script.sh
+++ b/bin/dde4_update_script.sh
@@ -157,13 +157,13 @@ else
 fi
 
 echo "Run any pending  migrations"
-cd $APP_DIR && DDE_HOST_URL=$DDE_HOST_URL RAILS_ENV=production $rails_path db:migrate
+cd $APP_DIR && DDE_HOST_URL=$DDE_HOST_URL RAILS_ENV=production $bundle_path exec rails db:migrate
 
 echo 'Precompile assets'
-cd $APP_DIR && DDE_HOST_URL=$DDE_HOST_URL RAILS_ENV=production $rails_path assets:clobber
+cd $APP_DIR && DDE_HOST_URL=$DDE_HOST_URL RAILS_ENV=production $bundle_path exec rails assets:clobber
 cd $APP_DIR && rm -rf tmp/cache
-cd $APP_DIR && DDE_HOST_URL=$DDE_HOST_URL RAILS_ENV=production $rails_path assets:precompile
-cd $APP_DIR && DDE_HOST_URL=$DDE_HOST_URL RAILS_ENV=production $rails_path tailwindcss:build
+cd $APP_DIR && DDE_HOST_URL=$DDE_HOST_URL RAILS_ENV=production $bundle_path exec rails assets:precompile
+cd $APP_DIR && DDE_HOST_URL=$DDE_HOST_URL RAILS_ENV=production $bundle_path exec rails tailwindcss:build
 
 
 if [[ $ruby_version_manager == 1 ]]; then


### PR DESCRIPTION
- Guard against empty token file before parsing JSON
- Handle nil/missing token key after parsing
- Rescue JSON::ParserError, NoMethodError, and TypeError for malformed structures
- Log warning to Rails logger and save error to sync_errors table before re-authenticating