### PR TITLE
feat: add allocated and unallocated counts to query

### DIFF
--- a/lib/dashboard_service.rb
+++ b/lib/dashboard_service.rb
@@ -79,6 +79,8 @@ module DashboardService
       l.activated,
       assigned.assigned,
       unassigned.unassigned,
+      max_updated.allocated,
+      max_updated.unallocated,
       date_last_updated,
       ROUND(assigned.assigned / DATEDIFF(date_last_updated, min_date_updated)) avg_consumption_rate_per_day
     FROM
@@ -87,7 +89,9 @@ module DashboardService
       SELECT
         location_id,
         max(updated_at) date_last_updated,
-        min(updated_at) min_date_updated
+        min(updated_at) min_date_updated,
+        SUM(CASE WHEN allocated = 1 OR assigned = 1 THEN 1 ELSE 0 END) allocated,
+        SUM(CASE WHEN allocated = 0 AND assigned = 0 THEN 1 ELSE 0 END) unallocated
       FROM
         location_npids
       GROUP BY

--- a/lib/dashboard_service.rb
+++ b/lib/dashboard_service.rb
@@ -79,7 +79,36 @@ module DashboardService
       l.activated,
       assigned.assigned,
       unassigned.unassigned,
-      max_updated.allocated,
+SELECT
+  l.name location_name,
+  l.location_id,
+  l.activated,
+  stats.assigned,
+  stats.unassigned,
+  stats.allocated,
+  stats.unallocated,
+  stats.date_last_updated,
+  ROUND(stats.assigned / DATEDIFF(stats.date_last_updated, stats.min_date_updated)) avg_consumption_rate_per_day
+FROM
+  locations l
+JOIN (
+  SELECT
+    location_id,
+    MAX(updated_at) date_last_updated,
+    MIN(updated_at) min_date_updated,
+    SUM(CASE WHEN allocated = 1 OR assigned = 1 THEN 1 ELSE 0 END) allocated,
+    SUM(CASE WHEN allocated = 0 AND assigned = 0 THEN 1 ELSE 0 END) unallocated,
+    SUM(CASE WHEN assigned = 1 THEN 1 ELSE 0 END) assigned,
+    SUM(CASE WHEN assigned = 0 THEN 1 ELSE 0 END) unassigned
+  FROM
+    location_npids
+  WHERE
+    location_id = #{ActiveRecord::Base.connection.quote(location_id)}
+  GROUP BY
+    location_id
+) stats ON l.location_id = stats.location_id
+WHERE
+  l.location_id = #{ActiveRecord::Base.connection.quote(location_id)};
       max_updated.unallocated,
       date_last_updated,
       ROUND(assigned.assigned / DATEDIFF(date_last_updated, min_date_updated)) avg_consumption_rate_per_day

--- a/lib/dashboard_service.rb
+++ b/lib/dashboard_service.rb
@@ -73,12 +73,6 @@ module DashboardService
 
   def self.location_npids(location_id)
     ActiveRecord::Base.connection.select_all("
-      SELECT
-      l.name location_name,
-      l.location_id,
-      l.activated,
-      assigned.assigned,
-      unassigned.unassigned,
 SELECT
   l.name location_name,
   l.location_id,
@@ -109,48 +103,6 @@ JOIN (
 ) stats ON l.location_id = stats.location_id
 WHERE
   l.location_id = #{ActiveRecord::Base.connection.quote(location_id)};
-      max_updated.unallocated,
-      date_last_updated,
-      ROUND(assigned.assigned / DATEDIFF(date_last_updated, min_date_updated)) avg_consumption_rate_per_day
-    FROM
-      locations l
-    JOIN (
-      SELECT
-        location_id,
-        max(updated_at) date_last_updated,
-        min(updated_at) min_date_updated,
-        SUM(CASE WHEN allocated = 1 OR assigned = 1 THEN 1 ELSE 0 END) allocated,
-        SUM(CASE WHEN allocated = 0 AND assigned = 0 THEN 1 ELSE 0 END) unallocated
-      FROM
-        location_npids
-      GROUP BY
-        location_id) max_updated
-          ON
-      l.location_id = max_updated.location_id
-    JOIN (
-      SELECT
-        ln.location_id,
-        count(*) assigned
-      FROM
-        location_npids ln
-      WHERE ln.assigned = 1
-      GROUP BY
-        location_id) assigned
-          ON
-      l.location_id = assigned.location_id
-    JOIN  (
-      SELECT
-        ln.location_id,
-        count(*) unassigned
-      FROM
-        location_npids ln
-      WHERE ln.assigned = 0
-      GROUP BY
-        location_id) unassigned
-          ON
-      l.location_id = unassigned.location_id
-    WHERE
-    l.location_id = #{ActiveRecord::Base.connection.quote(location_id)};
       ")
   end
 


### PR DESCRIPTION
Add aggregated allocated and unallocated count metrics to the DashboardService SQL query, including the SUM CASE statements in the location_npids subquery and including the new columns in the main select list.